### PR TITLE
feat: [PLATO-0000] hero banner calculation fix

### DIFF
--- a/src/components/features/hero-banner/HeroBanner.tsx
+++ b/src/components/features/hero-banner/HeroBanner.tsx
@@ -65,7 +65,7 @@ export const HeroBanner = ({
 
     window.addEventListener('resize', handleFontSize);
     return () => window.removeEventListener('resize', handleFontSize);
-  }, []);
+  }, [headingVisible]);
 
   return (
     <Grid position="relative" gridRow={2} gridColumn={1} mt={`-${HEADER_HEIGHT}px`}>


### PR DESCRIPTION
**_What will change?_**

- The calculation initially needs to run twice, to correctly set the scale. As such, passing the headingVisible prop makes sure the effect runs twice to correct itself after the title is visible
