### PR TITLE
feat: [PLATO-409] enable npm token access from vault

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,3 +3,4 @@ services:
   github-action:
     policies:
     - dependabot
+    - npm-read


### PR DESCRIPTION
**_What will change?_**

Changed policy to enable use of `npm-read` in GHA.