### PR TITLE
feat: [PLATO-623] update tracking plan

### DIFF
--- a/analytics/index.ts
+++ b/analytics/index.ts
@@ -27,7 +27,7 @@ export interface ContentModelInteracted {
  * Fired when a guest space is active. A guest space is active when at least a spaceId, CDA
  * token and CPA token are provided as url parameters. Optionally a domain can be passed.
  *
- * Guest spaces are used for Contentful’s Entry preview links.
+ * Guest spaces are used for Contentfuls Entry preview links.
  */
 export interface GuestSpaceActive {
     /**
@@ -42,6 +42,17 @@ export interface GuestSpaceActive {
  */
 export interface PreviewModeInteracted {
     enabled: boolean;
+    [property: string]: any;
+}
+
+/**
+ * Fired when a user interacts with the sign up banner on the public template preview.
+ */
+export interface SignUpBannerInteracted {
+    /**
+     * The CTA to sign up and auto-install the template from the banner.
+     */
+    ctaClicked: boolean;
     [property: string]: any;
 }
 
@@ -86,6 +97,14 @@ export class Convert {
 
     public static previewModeInteractedToJson(value: PreviewModeInteracted): string {
         return JSON.stringify(uncast(value, r("PreviewModeInteracted")), null, 2);
+    }
+
+    public static toSignUpBannerInteracted(json: string): SignUpBannerInteracted {
+        return cast(JSON.parse(json), r("SignUpBannerInteracted"));
+    }
+
+    public static signUpBannerInteractedToJson(value: SignUpBannerInteracted): string {
+        return JSON.stringify(uncast(value, r("SignUpBannerInteracted")), null, 2);
     }
 
     public static toToolboxInteracted(json: string): ToolboxInteracted {
@@ -248,6 +267,9 @@ const typeMap: any = {
     ], "any"),
     "PreviewModeInteracted": o([
         { json: "enabled", js: "enabled", typ: true },
+    ], "any"),
+    "SignUpBannerInteracted": o([
+        { json: "ctaClicked", js: "ctaClicked", typ: true },
     ], "any"),
     "ToolboxInteracted": o([
         { json: "isOpen", js: "isOpen", typ: true },
@@ -501,7 +523,7 @@ export function contentModelInteracted(props: ContentModelInteracted, options?: 
  */
 export function guestSpaceActive(props: GuestSpaceActive, options?: Options, callback?: Callback): void {
 
-    const schema = {"$id":"guest_space_active","description":"Fired when a guest space is active. A guest space is active when at least a spaceId, CDA token and CPA token are provided as url parameters. Optionally a domain can be passed.\n\nGuest spaces are used for Contentful’s Entry preview links.","properties":{"spaceId":{"$id":"/properties/spaceId","description":"Unique id of a user's space","type":"string"}},"required":["spaceId"],"type":"object"};
+    const schema = {"$id":"guest_space_active","description":"Fired when a guest space is active. A guest space is active when at least a spaceId, CDA token and CPA token are provided as url parameters. Optionally a domain can be passed.\n\nGuest spaces are used for Contentfuls Entry preview links.","properties":{"spaceId":{"$id":"/properties/spaceId","description":"Unique id of a user's space","type":"string"}},"required":["spaceId"],"type":"object"};
     validateAgainstSchema(props, schema);
 
     const a = analytics();
@@ -531,6 +553,30 @@ export function previewModeInteracted(props: PreviewModeInteracted, options?: Op
     const a = analytics();
     if (a) {
         a.track('preview_mode_interacted', props || {}, {...options,   context: {
+            ...(options?.context || {}),
+            typewriter: {
+                language: 'typescript',
+                version: '',
+            },
+        },}, callback);
+    }
+}
+/**
+ * Fires a 'SignUpBannerInteracted' track call.
+ *
+ * @param SignUpBannerInteracted props - The analytics properties that will be sent to Segment.
+ * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 	call is fired.
+ */
+export function signUpBannerInteracted(props: SignUpBannerInteracted, options?: Options, callback?: Callback): void {
+
+    const schema = {"$id":"sign_up_banner_interacted","description":"Fired when a user interacts with the sign up banner on the public template preview.","properties":{"ctaClicked":{"$id":"/properties/ctaClicked","description":"The CTA to sign up and auto-install the template from the banner.","type":"boolean"}},"required":["ctaClicked"],"type":"object"};
+    validateAgainstSchema(props, schema);
+
+    const a = analytics();
+    if (a) {
+        a.track('sign_up_banner_interacted', props || {}, {...options,   context: {
             ...(options?.context || {}),
             typewriter: {
                 language: 'typescript',
@@ -631,6 +677,15 @@ const clientAPI = {
      * 	call is fired.
      */
     previewModeInteracted,
+    /**
+     * Fires a 'SignUpBannerInteracted' track call.
+     *
+     * @param SignUpBannerInteracted props - The analytics properties that will be sent to Segment.
+     * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+     * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+     * 	call is fired.
+     */
+    signUpBannerInteracted,
     /**
      * Fires a 'ToolboxInteracted' track call.
      *

--- a/analytics/plan.json
+++ b/analytics/plan.json
@@ -45,7 +45,7 @@
       "deprecatedAt": "0001-01-01T00:00:00.000Z",
       "jsonSchema": {
         "$id": "guest_space_active",
-        "description": "Fired when a guest space is active. A guest space is active when at least a spaceId, CDA token and CPA token are provided as url parameters. Optionally a domain can be passed.\n\nGuest spaces are used for Contentful’s Entry preview links.",
+        "description": "Fired when a guest space is active. A guest space is active when at least a spaceId, CDA token and CPA token are provided as url parameters. Optionally a domain can be passed.\n\nGuest spaces are used for Contentfuls Entry preview links.",
         "eventMetadata": {
           "name": "guest_space_active",
           "type": "TRACK"
@@ -62,7 +62,7 @@
       },
       "key": "guest_space_active",
       "type": "TRACK",
-      "updatedAt": "2023-02-21T10:25:37.000Z",
+      "updatedAt": "2023-04-06T14:39:41.000Z",
       "version": 1
     },
     {
@@ -88,6 +88,31 @@
       "key": "preview_mode_interacted",
       "type": "TRACK",
       "updatedAt": "2023-02-21T10:25:37.000Z",
+      "version": 1
+    },
+    {
+      "createdAt": "2023-05-08T15:04:12.000Z",
+      "deprecatedAt": "0001-01-01T00:00:00.000Z",
+      "jsonSchema": {
+        "$id": "sign_up_banner_interacted",
+        "description": "Fired when a user interacts with the sign up banner on the public template preview.",
+        "eventMetadata": {
+          "name": "sign_up_banner_interacted",
+          "type": "TRACK"
+        },
+        "properties": {
+          "ctaClicked": {
+            "$id": "/properties/ctaClicked",
+            "description": "The CTA to sign up and auto-install the template from the banner.",
+            "type": "boolean"
+          }
+        },
+        "required": ["ctaClicked"],
+        "type": "object"
+      },
+      "key": "sign_up_banner_interacted",
+      "type": "TRACK",
+      "updatedAt": "2023-05-08T15:50:18.000Z",
       "version": 1
     },
     {
@@ -143,5 +168,5 @@
   ],
   "slug": "",
   "type": "LIVE",
-  "updatedAt": "2023-02-21T14:24:39.000Z"
+  "updatedAt": "2023-05-08T15:50:18.000Z"
 }


### PR DESCRIPTION
**_What will change?_**

This introduces the new `signUpBannerInteracted` tracking event to the Typewriter schema for its usage in https://contentful.atlassian.net/browse/PLATO-624.

Usage will look like this:

```TypeScript
typewriter.signUpBannerInteracted({ ctaClicked: true }) // true/false
```

Ticket: https://contentful.atlassian.net/browse/PLATO-623