### PR TITLE
chore: [PLATO-718] update the CSP header domains

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -13,7 +13,7 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com`,
+    value: `frame-ancestors 'self' https://app.contentful.com https://app.flinkly.com https://app.quirely.com http://localhost:3001`,
   },
   {
     key: 'X-Content-Type-Options',


### PR DESCRIPTION
**_What will change?_**

We introduce domains to be able to work with the Contentful Live Preview on non-production environments.

Ticket: https://contentful.atlassian.net/browse/PLATO-718

--- 

**Before introducing the domains**

<img width="1496" alt="localhost-before" src="https://github.com/contentful/template-ecommerce-webapp-nextjs/assets/103024358/2253c6b3-7106-4680-95e6-ce7287c85a64">

**After introducing the domains**

<img width="1500" alt="localhost-after" src="https://github.com/contentful/template-ecommerce-webapp-nextjs/assets/103024358/5b9969c7-7577-4c0c-bb9a-5d751231378c">
