### PR TITLE
fix: [PLATO-842] Add domains to CSP and image optimaization

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -13,7 +13,7 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com https://app.flinkly.com https://app.quirely.com http://localhost:3001`,
+    value: `frame-ancestors 'self' https://app.contentful.com https://app.flinkly.com https://app.quirely.com http://localhost:3001 https://app.eu.contentful.com`,
   },
   {
     key: 'X-Content-Type-Options',

--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,12 @@ const moduleExports = withPlugins(plugins, {
    * Settings are the defaults
    */
   images: {
-    domains: ['images.ctfassets.net', 'images.flinkly.com', 'images.quirely.com'],
+    domains: [
+      'images.ctfassets.net',
+      'images.eu.ctfassets.net',
+      'images.flinkly.com',
+      'images.quirely.com',
+    ],
   },
 
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],


### PR DESCRIPTION
What will change?

- added 'app.eu.contentful.com' to Content-Security-Policy so that it would allow the site to be embed in an iframe from the eu-contentful.
- added 'images.eu.ctfassets.net' to images - domains
- 
ticket: https://contentful.atlassian.net/browse/PLATO-842