### PR TITLE
fix: incorrect error message when .env already exists

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,7 +2,7 @@
 
 # Check if .env file already exists
 if [ -f .env ]; then
-  echo ".env.example file does not exist. Aborting."
+  echo ".env already exists. Aborting."
   exit 1
 fi
 


### PR DESCRIPTION
Just a one line change, error message displayed when .env already exists is incorrect so I changed it to something more appropriate
