### PR TITLE
chore: fix dependabot on private

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+registries:
+  npm-registry-registry-npmjs-org:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: '${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}'
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '05:00'
+      timezone: UTC
+    commit-message:
+      prefix: build
+      include: scope
+    labels:
+      - 'dependencies'
+      - 'dependabot'
+      - 'main-private'
+    open-pull-requests-limit: 2
+    reviewers:
+      - 'contentful/team-tolkien'
+    registries:
+      - npm-registry-registry-npmjs-org
+    allow:
+      - dependency-name: '@contentful/live-preview'
+    target-branch: 'main-private'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '05:00'
+      timezone: UTC
+    open-pull-requests-limit: 15
+    commit-message:
+      prefix: build
+      include: scope
+    target-branch: 'main-private'


### PR DESCRIPTION
We'll see if this fixes the missing secrets on the dependabot PRs for this branch, if so then it'll be duplicated to the other templates and the `main-private` config removed from `main`