### PR TITLE
fix: do not import directly from `dist` folder

### DIFF
--- a/src/components/features/contentful/ctf-image/CtfImage.tsx
+++ b/src/components/features/contentful/ctf-image/CtfImage.tsx
@@ -1,11 +1,11 @@
-import type { InspectorModeTags } from '@contentful/live-preview/dist/inspectorMode/types';
+import type { ContentfulLivePreview } from '@contentful/live-preview';
 import NextImage, { ImageProps as NextImageProps } from 'next/image';
 
 import { ImageFieldsFragment } from '@src/lib/__generated/sdk';
 
 interface ImageProps extends ImageFieldsFragment {
   imageProps?: Omit<NextImageProps, 'src' | 'alt'>;
-  livePreviewProps?: InspectorModeTags;
+  livePreviewProps?: typeof ContentfulLivePreview.getProps;
 }
 
 export const CtfImage = ({

--- a/src/components/features/contentful/ctf-image/CtfImage.tsx
+++ b/src/components/features/contentful/ctf-image/CtfImage.tsx
@@ -5,7 +5,7 @@ import { ImageFieldsFragment } from '@src/lib/__generated/sdk';
 
 interface ImageProps extends ImageFieldsFragment {
   imageProps?: Omit<NextImageProps, 'src' | 'alt'>;
-  livePreviewProps?: typeof ContentfulLivePreview.getProps;
+  livePreviewProps?: ReturnType<typeof ContentfulLivePreview.getProps>;
 }
 
 export const CtfImage = ({


### PR DESCRIPTION
We don't want to import from `@contentful/live-preview/dist/...`

Closes https://github.com/contentful/template-ecommerce-webapp-nextjs/issues/139