### PR TITLE
chore: copy CODEOWNERS from `main` [CFISO-2441]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @contentful/team-isotopes
+package.json
+yarn.lock


### PR DESCRIPTION
This will allow renovate to auto-merge. Currently it's stuck because a code owner's review is required