### PR TITLE
feat: reference migration to Experience Orchestration [ATL-541]

### DIFF
--- a/.github/workflows/eslint-tsc.yml
+++ b/.github/workflows/eslint-tsc.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -20,6 +21,9 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
+          registry-url: https://npm.pkg.github.com
+          scope: '@contentful'
+          always-auth: true
 
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
@@ -34,6 +38,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # `--prefer-offline` gives cache priority
 
       - name: ESLint

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 ignore-scripts=true
 @contentful:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 ignore-scripts=true
+@contentful:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/config/headers.js
+++ b/config/headers.js
@@ -1,40 +1,55 @@
-const securityHeaders = [
-  {
-    key: 'X-DNS-Prefetch-Control',
-    value: 'on',
-  },
-  {
-    key: 'Strict-Transport-Security',
-    value: 'max-age=63072000; includeSubDomains; preload',
-  },
-  {
-    key: 'X-Frame-Options',
-    value: 'SAMEORIGIN',
-  },
+/**
+ * Security headers.
+ *
+ * Two profiles:
+ * - `/preview` — allows the Contentful editor to iframe the app. Drops X-Frame-Options (its only
+ *   options are SAMEORIGIN or the deprecated single-origin ALLOW-FROM — it cannot express a
+ *   multi-origin allow-list). Lists the editor origins in `frame-ancestors`. See
+ *   reference/05-preview.md, "three iframe guards".
+ * - everything else — deny-by-default framing.
+ *
+ * The editor origins include the two prod hosts and the staging host (`app.flinkly.com`); adjust
+ * per environment.
+ */
+
+const EDITOR_ORIGINS = [
+  'https://app.contentful.com',
+  'https://app.eu.contentful.com',
+  'https://app.flinkly.com',
+];
+
+const baseHeaders = [
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-XSS-Protection', value: '1; mode=block' },
+  { key: 'Referrer-Policy', value: 'no-referrer' },
+];
+
+const strictHeaders = [
+  ...baseHeaders,
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'Content-Security-Policy', value: `frame-ancestors 'self'` },
+];
+
+const previewHeaders = [
+  ...baseHeaders,
+  // No X-Frame-Options on /preview — CSP frame-ancestors carries the policy instead.
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com https://app.eu.contentful.com`,
-  },
-  {
-    key: 'X-Content-Type-Options',
-    value: 'nosniff',
-  },
-  {
-    key: 'X-XSS-Protection',
-    value: '1; mode=block',
-  },
-  {
-    key: 'Referrer-Policy',
-    value: 'no-referrer',
+    value: `frame-ancestors 'self' ${EDITOR_ORIGINS.join(' ')}`,
   },
 ];
 
 module.exports = async () => {
   return [
-    {
-      // Apply these headers to all routes in your application.
-      source: '/:path*',
-      headers: securityHeaders,
-    },
+    // The /preview route needs to be iframed by the Contentful editor.
+    { source: '/preview', headers: previewHeaders },
+    { source: '/preview/', headers: previewHeaders },
+    // Everything else gets deny-by-default framing. Two rules — an explicit root and a catch-all
+    // that excludes /preview — because a bare `/((?!preview).*)` source does NOT match the bare
+    // root `/` in Next.js's header router.
+    { source: '/', headers: strictHeaders },
+    { source: '/((?!preview$|preview/).*)', headers: strictHeaders },
   ];
 };

--- a/next.config.js
+++ b/next.config.js
@@ -46,6 +46,20 @@ module.exports = withPlugins(plugins, {
   compress: true,
 
   /**
+   * ExO SDK (pre-alpha): the five `@contentful/experiences-*` packages ship an ESM build with
+   * extensionless relative imports. Node's native ESM resolver rejects those at Next's
+   * page-data-collect step; forcing Next to bundle+transpile them through webpack fixes it.
+   * REMOVE when the SDK ships a spec-compliant ESM build.
+   */
+  transpilePackages: [
+    '@contentful/experiences-react',
+    '@contentful/experiences-client',
+    '@contentful/experiences-sdk-core',
+    '@contentful/experiences-design',
+    '@contentful/experience-delivery',
+  ],
+
+  /**
    * add the headers you would like your next server to use
    * documentation: https://nextjs.org/docs/api-reference/next.config.js/headers
    *                https://nextjs.org/docs/advanced-features/security-headers
@@ -57,7 +71,9 @@ module.exports = withPlugins(plugins, {
    * Settings are the defaults
    */
   images: {
-    domains: ['images.ctfassets.net', 'images.eu.ctfassets.net'],
+    // Add the ExO delivery image host so next/image will optimize ETL-served assets.
+    // `images.flinkly.com` is staging; `images.ctfassets.net` is the prod host.
+    domains: ['images.ctfassets.net', 'images.eu.ctfassets.net', 'images.flinkly.com'],
   },
 
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@chakra-ui/react": "2.4.1",
     "@contentful/f36-icons": "4.29.1",
+    "@contentful/experiences-react": "0.5.6",
     "@contentful/f36-tokens": "5.1.0",
     "@contentful/live-preview": "4.9.0",
     "@emotion/react": "11.14.0",

--- a/src/components/templates/layout/layout.tsx
+++ b/src/components/templates/layout/layout.tsx
@@ -13,7 +13,11 @@ export const Layout = ({ children }: LayoutPropsInterface) => {
   const router = useRouter();
   const theme = useTheme();
 
-  const isHomePage = router.pathname === '/';
+  // Route-path allow-list for the borderless homepage header chrome. `/preview` is included so
+  // the editor iframe render matches the delivery route rather than showing a stray header
+  // border (see reference/05-preview.md §2.5).
+  const LANDING_ROUTES = ['/', '/preview'];
+  const isHomePage = LANDING_ROUTES.includes(router.pathname);
 
   return (
     <>

--- a/src/lib/exo/adapters/HeroBannerAdapter.tsx
+++ b/src/lib/exo/adapters/HeroBannerAdapter.tsx
@@ -1,0 +1,41 @@
+import { useDesignValues } from '@contentful/experiences-react';
+
+import { HeroBanner } from '@src/components/features/hero-banner';
+import type { PageLandingFieldsFragment } from '@src/lib/__generated/sdk';
+
+import { IMAGE_RATIOS, toImageFragment } from '../shared';
+
+/**
+ * Flat props emitted by the ExO delivery payload for the `hero-banner` componentType.
+ * `headlineColor` is a design property and is read via `useDesignValues()`, not injected.
+ */
+export interface HeroBannerExoProps {
+  headline?: string | null;
+  /** Bare URL string (image dimensions are not carried in this payload — see shared.ts). */
+  image?: string | null;
+}
+
+interface HeroBannerDesign {
+  headlineColor?: string;
+}
+
+/**
+ * ExO adapter for the `hero-banner` componentType.
+ * Flat ExO props → PageLandingFieldsFragment shape → the app's existing HeroBanner component.
+ */
+export function HeroBannerAdapter({ headline, image }: HeroBannerExoProps) {
+  const design = useDesignValues<HeroBannerDesign>();
+
+  const page: PageLandingFieldsFragment = {
+    __typename: 'PageLanding',
+    heroBannerHeadline: headline ?? null,
+    heroBannerHeadlineColor: design.headlineColor ?? null,
+    heroBannerImage: toImageFragment(image, IMAGE_RATIOS.hero, headline),
+    seoFields: null,
+    productsCollection: null,
+    internalName: null,
+    sys: { __typename: 'Sys', id: 'exo-hero', spaceId: '' },
+  };
+
+  return <HeroBanner {...page} />;
+}

--- a/src/lib/exo/adapters/LandingTemplateAdapter.tsx
+++ b/src/lib/exo/adapters/LandingTemplateAdapter.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+/**
+ * ExO template adapter for the `landing-page` template.
+ *
+ * The delivery payload's inline template-variant node is flattened by
+ * `normalize-payload.ts`, so slot children arrive here already rendered.
+ * This template is a passthrough — it just returns its children. The app's
+ * page chrome (Layout, header, footer) is provided by _app.page.tsx.
+ */
+export function LandingTemplateAdapter({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/lib/exo/adapters/ProductTileAdapter.tsx
+++ b/src/lib/exo/adapters/ProductTileAdapter.tsx
@@ -1,0 +1,37 @@
+import { ProductTile } from '@src/components/features/product';
+import type { PageProductFieldsFragment } from '@src/lib/__generated/sdk';
+
+import { IMAGE_RATIOS, toImageFragment, toNumber } from '../shared';
+
+/**
+ * Flat props emitted by the ExO delivery payload for the `product-tile` componentType.
+ * `price` is delivered as a real JSON number today; the defensive `toNumber` coercion keeps
+ * things safe if the schema ever switches to string.
+ */
+export interface ProductTileExoProps {
+  slug?: string | null;
+  price?: number | string | null;
+  /** Bare URL string (image dimensions are not carried in this payload — see shared.ts). */
+  image?: string | null;
+}
+
+/**
+ * ExO adapter for the `product-tile` componentType.
+ * Flat ExO props → PageProductFieldsFragment shape → the app's existing ProductTile component.
+ */
+export function ProductTileAdapter({ slug, price, image }: ProductTileExoProps) {
+  const product: PageProductFieldsFragment = {
+    __typename: 'PageProduct',
+    slug: slug ?? null,
+    price: toNumber(price),
+    featuredProductImage: toImageFragment(image, IMAGE_RATIOS.productTile, slug),
+    internalName: null,
+    name: null,
+    description: null,
+    seoFields: null,
+    productImagesCollection: null,
+    relatedProductsCollection: null,
+    sys: { __typename: 'Sys', id: slug ?? 'exo-product-tile', spaceId: '' },
+  };
+  return <ProductTile {...product} />;
+}

--- a/src/lib/exo/adapters/ProductTileGridAdapter.tsx
+++ b/src/lib/exo/adapters/ProductTileGridAdapter.tsx
@@ -1,0 +1,45 @@
+import { Box, Container, Grid, Heading } from '@chakra-ui/react';
+import { useTranslation } from 'next-i18next';
+import type { ReactNode } from 'react';
+
+/**
+ * Flat props emitted by the ExO delivery payload for the `product-tile-grid` componentType.
+ * `tiles` is delivered as a single pre-rendered ReactNode by the SDK (NOT a data array).
+ * `title` is optional — if unset, we fall back to the app's i18n label so the section header
+ * matches the pre-ExO render (see reference/02-adapter-pattern.md — "app chrome is not content").
+ */
+export interface ProductTileGridExoProps {
+  title?: string | null;
+  tiles?: ReactNode;
+}
+
+/**
+ * ExO adapter for the `product-tile-grid` componentType.
+ * Reproduces the thin layout shell (Box spacing → Container → optional Heading → Grid) from
+ * the customer's ProductTileGrid component, and drops the pre-rendered slot children inside.
+ * The `mt` spacing is page-composition chrome (from the source page's JSX), not content —
+ * see reference/02-adapter-pattern.md.
+ */
+export function ProductTileGridAdapter({ title, tiles }: ProductTileGridExoProps) {
+  const { t } = useTranslation();
+  const heading = title || t('product.trendingProducts');
+
+  return (
+    <Box mt={{ base: 5, md: 9, lg: 16 }}>
+      <Container>
+        {heading && (
+          <Heading as="h2" mb={3}>
+            {heading}
+          </Heading>
+        )}
+        <Grid
+          templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(3, 1fr)' }}
+          rowGap={{ base: 6, lg: 6 }}
+          columnGap={{ base: 4, lg: 24 }}
+        >
+          {tiles}
+        </Grid>
+      </Container>
+    </Box>
+  );
+}

--- a/src/lib/exo/adapters/SeoAdapter.tsx
+++ b/src/lib/exo/adapters/SeoAdapter.tsx
@@ -1,0 +1,43 @@
+import { SeoFields } from '@src/components/features/seo';
+import type { SeoFieldsFragment } from '@src/lib/__generated/sdk';
+
+import { IMAGE_RATIOS, toImageFragment } from '../shared';
+
+/**
+ * Flat props emitted by the ExO delivery payload for the `seo` componentType.
+ * Keys come from the data assembly's `dataType` — verified in the XPA response.
+ */
+export interface SeoExoProps {
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  canonicalUrl?: string | null;
+  noindex?: boolean | null;
+  nofollow?: boolean | null;
+  /** Bare URL string (image dimensions are not carried in this payload — see shared.ts). */
+  shareImages?: string | null;
+}
+
+/**
+ * ExO adapter for the `seo` componentType.
+ * Flat ExO props → SeoFieldsFragment shape → the app's existing SeoFields component, untouched.
+ */
+export function SeoAdapter({
+  pageTitle,
+  pageDescription,
+  canonicalUrl,
+  noindex,
+  nofollow,
+  shareImages,
+}: SeoExoProps) {
+  const image = toImageFragment(shareImages, IMAGE_RATIOS.share, pageTitle);
+  const seo: SeoFieldsFragment = {
+    __typename: 'ComponentSeo',
+    pageTitle: pageTitle ?? null,
+    pageDescription: pageDescription ?? null,
+    canonicalUrl: canonicalUrl ?? null,
+    noindex: noindex ?? null,
+    nofollow: nofollow ?? null,
+    shareImagesCollection: image ? { __typename: 'AssetCollection', items: [image] } : null,
+  };
+  return <SeoFields {...seo} />;
+}

--- a/src/lib/exo/experience-config.tsx
+++ b/src/lib/exo/experience-config.tsx
@@ -1,0 +1,30 @@
+import { defineComponent, defineTemplate, type Config } from '@contentful/experiences-react';
+
+import { HeroBannerAdapter } from './adapters/HeroBannerAdapter';
+import { LandingTemplateAdapter } from './adapters/LandingTemplateAdapter';
+import { ProductTileAdapter } from './adapters/ProductTileAdapter';
+import { ProductTileGridAdapter } from './adapters/ProductTileGridAdapter';
+import { SeoAdapter } from './adapters/SeoAdapter';
+
+/**
+ * ExO component + template registry.
+ *
+ * Keys are ExO ids = last slash-segment of `componentType.sys.urn` (or `sys.template.sys.urn`),
+ * case-sensitive. NEVER display names, NEVER source content-type ids.
+ *
+ * `product-details` is defined in the ExO schema for parameterized product routes; those routes
+ * are out of scope for the static-route refactor (see codebase-analysis/pages.json → `/[slug]`).
+ * It is intentionally left unregistered here — if the payload ever contains a product-details
+ * node, the SDK renders `MissingComponent` and surfaces the id, which is the right signal.
+ */
+export const experienceConfig: Config = {
+  components: {
+    seo: defineComponent({ component: SeoAdapter }),
+    'hero-banner': defineComponent({ component: HeroBannerAdapter }),
+    'product-tile-grid': defineComponent({ component: ProductTileGridAdapter }),
+    'product-tile': defineComponent({ component: ProductTileAdapter }),
+  },
+  templates: {
+    'landing-page': defineTemplate({ component: LandingTemplateAdapter }),
+  },
+};

--- a/src/lib/exo/normalize-payload.ts
+++ b/src/lib/exo/normalize-payload.ts
@@ -1,0 +1,69 @@
+import type { ExperiencePayload, ExperienceNode } from '@contentful/experiences-react';
+
+/**
+ * Bridge for the inline-template-variant-node blocker (see reference/01-payload-shape.md).
+ *
+ * The ETL-seeded landing experience arrives as a SINGLE template-variant node whose named
+ * slots hold the page sections:
+ *
+ *   payload.nodes = [{ template, slots: { seo:[S], hero:[H], products:[P] } }]
+ *
+ * But `@contentful/experiences-react@0.5.6`'s `resolveExperience` treats any node without a
+ * `componentType` key as unsupported and returns null — so a raw payload resolves 0 nodes and
+ * renders nothing.
+ *
+ * The fix: lift the template node's slot children up into a flat, ordered `nodes` array and
+ * expose the template at `sys.template`. Render order is fixed to the source page's section
+ * order: SEO (head-only), then hero, then products.
+ *
+ * REMOVE this file when the SDK supports inline templates natively.
+ */
+
+const KNOWN_SLOT_ORDER = ['seo', 'hero', 'products'] as const;
+
+function isTemplateVariantNode(node: unknown): node is {
+  template: { sys: { urn?: string } };
+  slots?: Record<string, ExperienceNode[]>;
+} {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'template' in (node as Record<string, unknown>) &&
+    !('componentType' in (node as Record<string, unknown>))
+  );
+}
+
+export function normalizeExperiencePayload(payload: ExperiencePayload): ExperiencePayload {
+  if (!payload || !Array.isArray(payload.nodes) || payload.nodes.length === 0) return payload;
+
+  const first = payload.nodes[0];
+  if (!isTemplateVariantNode(first)) return payload;
+
+  const slots = first.slots ?? {};
+  const seen = new Set<string>();
+  const flat: ExperienceNode[] = [];
+
+  for (const slotName of KNOWN_SLOT_ORDER) {
+    if (Array.isArray(slots[slotName])) {
+      for (const child of slots[slotName]) flat.push(child);
+      seen.add(slotName);
+    }
+  }
+  // Any additional slot the template gains later is appended (nothing silently dropped).
+  for (const [slotName, children] of Object.entries(slots)) {
+    if (seen.has(slotName)) continue;
+    if (Array.isArray(children)) for (const child of children) flat.push(child);
+  }
+
+  const nextSys = payload.sys ? { ...payload.sys } : ({} as ExperiencePayload['sys']);
+  // Expose the template at sys.template so the registry's template component wraps the nodes.
+  if (nextSys && !('template' in (nextSys as Record<string, unknown>))) {
+    (nextSys as { template?: unknown }).template = first.template;
+  }
+
+  return {
+    ...payload,
+    sys: nextSys,
+    nodes: flat,
+  };
+}

--- a/src/lib/exo/shared.ts
+++ b/src/lib/exo/shared.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared helpers for ExO adapters.
+ *
+ * REMOVE the `toImageFragment` shim (and IMAGE_RATIOS) when the ETL delivery payload starts
+ * carrying real image dimensions (width, height, title). Today the ETL models each image as a
+ * bare URL string; `next/image` (used by CtfImage) hard-requires width+height, so we synthesize
+ * a representative aspect ratio per usage so the render is not blank. Actual on-screen size is
+ * driven by surrounding CSS (hero forces object-fit inside a maxHeight, grid sizes by column),
+ * so a representative ratio is visually correct.
+ */
+
+import { ImageFieldsFragment } from '@src/lib/__generated/sdk';
+
+export const IMAGE_RATIOS = {
+  hero: { width: 1600, height: 900 },
+  productTile: { width: 600, height: 800 },
+  productDetails: { width: 800, height: 1000 },
+  share: { width: 1200, height: 630 },
+} as const;
+
+/**
+ * Synthesize an ImageFieldsFragment from a bare URL string so the app's existing CtfImage
+ * component (which requires width+height) renders. Remove when the delivery payload carries
+ * real dimensions.
+ */
+export function toImageFragment(
+  url: string | null | undefined,
+  ratio: { width: number; height: number },
+  title?: string | null,
+): ImageFieldsFragment | null {
+  if (!url || typeof url !== 'string') return null;
+  return {
+    __typename: 'Asset',
+    url,
+    width: ratio.width,
+    height: ratio.height,
+    title: title ?? null,
+    description: null,
+    contentType: null,
+    sys: { __typename: 'Sys', id: url },
+  };
+}
+
+/**
+ * Defensive numeric coercion — a no-op on real numbers. The ETL's product-tile.price is declared
+ * type:"Number" and arrives as a real JSON number today, but keep the coercion so a
+ * modeling-side switch to string doesn't silently break the render.
+ */
+export function toNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const n = parseFloat(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -3,7 +3,7 @@ import { ContentfulLivePreviewProvider } from '@contentful/live-preview/react';
 import localFont from '@next/font/local';
 import { appWithTranslation } from 'next-i18next';
 import type { AppProps } from 'next/app';
-import { useRouter } from "next/router"
+import { useRouter } from 'next/router';
 
 import { Layout } from '@src/components/templates/layout';
 import { theme } from '@src/theme';
@@ -63,14 +63,27 @@ const spaceGrotesk = localFont({
   ],
 });
 
+// Contentful Live Preview SDK — targetOrigin allow-list. Must be a NEXT_PUBLIC_ var (read
+// client-side). Include the ExO editor origins so /preview does not crash with
+// "current origin is not supported" → React #423. See reference/05-preview.md guard 2c.
+const PREVIEW_TARGET_ORIGINS = (
+  process.env.NEXT_PUBLIC_CTF_PREVIEW_TARGET_ORIGINS ??
+  'https://app.contentful.com,https://app.eu.contentful.com'
+)
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
 const App = ({ Component, pageProps }: AppProps) => {
-  const router = useRouter()
+  const router = useRouter();
 
   return (
     <ContentfulLivePreviewProvider
       locale={router.locale || 'en-US'}
       enableInspectorMode={pageProps.previewActive}
-      enableLiveUpdates={pageProps.previewActive}>
+      enableLiveUpdates={pageProps.previewActive}
+      targetOrigin={PREVIEW_TARGET_ORIGINS}
+    >
       <ChakraProvider
         theme={{
           ...theme,
@@ -78,7 +91,8 @@ const App = ({ Component, pageProps }: AppProps) => {
             heading: `${spaceGrotesk.style.fontFamily}, ${theme.fonts.heading}`,
             body: `${spaceGrotesk.style.fontFamily}, ${theme.fonts.body}`,
           },
-        }}>
+        }}
+      >
         <Layout>
           <Component {...pageProps} />
         </Layout>

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,63 +1,58 @@
-import { Box } from '@chakra-ui/react';
-import { useContentfulLiveUpdates } from '@contentful/live-preview/react';
+import {
+  createClient,
+  resolveExperience,
+  ServerExperienceRenderer,
+} from '@contentful/experiences-react';
+import type {
+  ExperiencePayload,
+  PortableRenderPlan,
+  ServerExperienceRendererProps,
+} from '@contentful/experiences-react';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import { useTranslation } from 'next-i18next';
+import type { ComponentType } from 'react';
 
-import { HeroBanner } from '@src/components/features/hero-banner';
-import { ProductTileGrid } from '@src/components/features/product';
-import { SeoFields } from '@src/components/features/seo';
-import { client, previewClient } from '@src/lib/client';
+import { experienceConfig } from '@src/lib/exo/experience-config';
+import { normalizeExperiencePayload } from '@src/lib/exo/normalize-payload';
 import { getServerSideTranslations } from '@src/pages/utils/get-serverside-translations';
 
-const Page = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const { t } = useTranslation();
-  const page = useContentfulLiveUpdates(props.page);
+// React-types cast (pre-alpha SDK). The SDK is built against React 19 types; the app pins
+// @types/react@18 which expects JSX children to be `ReactElement | null`. Cast once at import.
+// REMOVE when the app and SDK agree on React types.
+const Renderer =
+  ServerExperienceRenderer as unknown as ComponentType<ServerExperienceRendererProps>;
 
-  return (
-    <>
-      {page.seoFields && <SeoFields {...page.seoFields} />}
-      <HeroBanner {...page} />
-      {page.productsCollection?.items && (
-        <Box
-          mt={{
-            base: 5,
-            md: 9,
-            lg: 16,
-          }}>
-          <ProductTileGrid
-            title={t('product.trendingProducts')}
-            products={page.productsCollection.items}
-          />
-        </Box>
-      )}
-    </>
-  );
+const Page = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  return <Renderer experience={props.plan} config={experienceConfig} />;
 };
 
-export const getServerSideProps: GetServerSideProps = async ({ locale, preview }) => {
+export const getServerSideProps: GetServerSideProps<{ plan: PortableRenderPlan }> = async ({
+  locale,
+}) => {
+  const { EXO_SPACE_ID, EXO_ENVIRONMENT_ID, EXO_EXPERIENCE_ID, EXO_DELIVERY_TOKEN } = process.env;
+  const host = process.env.EXO_DELIVERY_HOST ?? 'https://xdn.contentful.com';
+
+  if (!EXO_SPACE_ID || !EXO_ENVIRONMENT_ID || !EXO_EXPERIENCE_ID || !EXO_DELIVERY_TOKEN) {
+    return { notFound: true };
+  }
+
   try {
-    const gqlClient = preview ? previewClient : client;
-
-    const data = await gqlClient.pageLanding({ locale, preview });
-
-    const page = data.pageLandingCollection?.items[0];
-
-    if (!page) {
-      return {
-        notFound: true,
-      };
-    }
-
+    const client = createClient({ accessToken: EXO_DELIVERY_TOKEN, host });
+    const raw = (await client.view.getExperience(
+      EXO_SPACE_ID,
+      EXO_ENVIRONMENT_ID,
+      EXO_EXPERIENCE_ID,
+      { locale: locale ?? 'en-US' },
+    )) as unknown as ExperiencePayload;
+    const normalized = normalizeExperiencePayload(raw);
+    const plan = await resolveExperience(normalized, experienceConfig);
     return {
       props: {
         ...(await getServerSideTranslations(locale)),
-        page,
+        plan,
       },
     };
   } catch {
-    return {
-      notFound: true,
-    };
+    return { notFound: true };
   }
 };
 

--- a/src/pages/preview.page.tsx
+++ b/src/pages/preview.page.tsx
@@ -1,0 +1,106 @@
+import {
+  createClient,
+  resolveExperience,
+  ServerExperienceRenderer,
+} from '@contentful/experiences-react';
+import type {
+  ExperiencePayload,
+  PortableRenderPlan,
+  ServerExperienceRendererProps,
+} from '@contentful/experiences-react';
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import type { ComponentType } from 'react';
+
+import { experienceConfig } from '@src/lib/exo/experience-config';
+import { normalizeExperiencePayload } from '@src/lib/exo/normalize-payload';
+import { getServerSideTranslations } from '@src/pages/utils/get-serverside-translations';
+
+// See index.page.tsx — pre-alpha SDK React-types bridge. REMOVE when SDK targets React 18.
+const Renderer =
+  ServerExperienceRenderer as unknown as ComponentType<ServerExperienceRendererProps>;
+
+type PreviewProps = { ok: true; plan: PortableRenderPlan } | { ok: false; error: string };
+
+const PreviewPage = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  if (!props.ok) {
+    // Visible error, not 404 — a 404 in the editor iframe is a blank frame with no diagnostics.
+    return (
+      <div style={{ padding: 24, fontFamily: 'system-ui', color: '#b91c1c', maxWidth: 720 }}>
+        <h1 style={{ marginBottom: 8, fontSize: 20 }}>ExO preview: cannot render</h1>
+        <p>{props.error}</p>
+      </div>
+    );
+  }
+  return <Renderer experience={props.plan} config={experienceConfig} />;
+};
+
+function firstStr(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+export const getServerSideProps: GetServerSideProps<PreviewProps> = async ({ locale, query }) => {
+  const spaceId = firstStr(query.spaceId) ?? process.env.EXO_SPACE_ID;
+  const environmentId = firstStr(query.environmentId) ?? process.env.EXO_ENVIRONMENT_ID;
+  const entityId = firstStr(query.entityId) ?? process.env.EXO_EXPERIENCE_ID;
+  const entityTypeRaw = firstStr(query.entityType);
+  const entityType = entityTypeRaw === 'fragment' ? 'fragment' : 'experience';
+  const variant = firstStr(query.variant);
+
+  const token = process.env.EXO_PREVIEW_TOKEN;
+  const host = process.env.EXO_PREVIEW_HOST ?? 'https://preview.xdn.contentful.com';
+  const translations = await getServerSideTranslations(locale);
+
+  if (!token) {
+    return {
+      props: { ...translations, ok: false as const, error: 'EXO_PREVIEW_TOKEN is not set.' },
+    };
+  }
+  if (!spaceId || !environmentId || !entityId) {
+    return {
+      props: {
+        ...translations,
+        ok: false as const,
+        error:
+          'Missing required parameter(s). Expected spaceId, environmentId, entityId in the URL or env.',
+      },
+    };
+  }
+
+  try {
+    const client = createClient({ accessToken: token, host });
+    const request = {
+      preview: 'true' as const,
+      locale: locale ?? 'en-US',
+      ...(variant ? { variant } : {}),
+    };
+    const raw =
+      entityType === 'fragment'
+        ? ((await client.fragment.getFragment(
+            spaceId,
+            environmentId,
+            entityId,
+            request,
+          )) as unknown as ExperiencePayload)
+        : ((await client.view.getExperience(
+            spaceId,
+            environmentId,
+            entityId,
+            request,
+          )) as unknown as ExperiencePayload);
+
+    const normalized = normalizeExperiencePayload(raw);
+    const plan = await resolveExperience(normalized, experienceConfig);
+    return { props: { ...translations, ok: true as const, plan } };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      props: {
+        ...translations,
+        ok: false as const,
+        error: `Preview fetch/resolve failed for ${entityType} ${entityId}: ${message}`,
+      },
+    };
+  }
+};
+
+export default PreviewPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,40 @@
     "@vercel/stega" "^0.1.2"
     json-pointer "^0.6.2"
 
+"@contentful/experience-delivery@1.0.0-dev.3":
+  version "1.0.0-dev.3"
+  resolved "https://npm.pkg.github.com/download/@contentful/experience-delivery/1.0.0-dev.3/0a0234e7760bb5aece7111374afb10bb4a3368c1#0a0234e7760bb5aece7111374afb10bb4a3368c1"
+  integrity sha512-EXnMOhq4a79xEGKcW2E8Osnc1eIGIm7KqMZwh8eHvyTReZIBfHBPzjb7xXFCqZEaFkjoufkcokV4qWoouLn9PQ==
+
+"@contentful/experiences-client@0.1.6":
+  version "0.1.6"
+  resolved "https://npm.pkg.github.com/download/@contentful/experiences-client/0.1.6/e642f3430db79d0eccf60598615eadfdfdc60d19#e642f3430db79d0eccf60598615eadfdfdc60d19"
+  integrity sha512-P/1IoV8T50iHBSKsRNL45ppjQ87GhyrmlSEpzXeFILRkoVkYpVy/Z1t8a+MntWpg/wFRxSLMcqM6b97weC9www==
+  dependencies:
+    "@contentful/experience-delivery" "1.0.0-dev.3"
+    "@contentful/experiences-sdk-core" "0.5.4"
+
+"@contentful/experiences-design@0.5.4":
+  version "0.5.4"
+  resolved "https://npm.pkg.github.com/download/@contentful/experiences-design/0.5.4/7c35e2d943f49eb947bdd7e6654d59a6e66f0120#7c35e2d943f49eb947bdd7e6654d59a6e66f0120"
+  integrity sha512-TZGwl7TbRo4aHT0yQgBoNx6eaH3509VoVnTNJ8UEE6+YuJFh0rO+4HQoj/PqjNTJTYzXSwrRWMKc2e8I/k2L3g==
+  dependencies:
+    "@contentful/experiences-sdk-core" "0.5.4"
+
+"@contentful/experiences-react@0.5.6":
+  version "0.5.6"
+  resolved "https://npm.pkg.github.com/download/@contentful/experiences-react/0.5.6/939254906fb0d0f716a7174bd0e231e9e8c1bbfa#939254906fb0d0f716a7174bd0e231e9e8c1bbfa"
+  integrity sha512-bSxGjgC6ewq/9AqEmvf3lPet/G/4uHKJ547/DZu2hCAkCxt/VOh/vB/NSbH8ktdAuvF+pZmPs05e+V2mTgI/ng==
+  dependencies:
+    "@contentful/experiences-client" "0.1.6"
+    "@contentful/experiences-design" "0.5.4"
+    "@contentful/experiences-sdk-core" "0.5.4"
+
+"@contentful/experiences-sdk-core@0.5.4":
+  version "0.5.4"
+  resolved "https://npm.pkg.github.com/download/@contentful/experiences-sdk-core/0.5.4/7ca2f9632a33417c4d801b0029dcbfe92416cfe2#7ca2f9632a33417c4d801b0029dcbfe92416cfe2"
+  integrity sha512-+kzxpl/Iju5nWUISDLKNcrmfSQsijSJTpH0OCR5m+9SAYIU34w2XXwCv3Rh0wNDhvMWOL6XxxeHHkFiUW/nxwQ==
+
 "@contentful/f36-core@^4.80.4", "@contentful/f36-core@^4.81.0":
   version "4.81.0"
   resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.81.0.tgz#7424657abea727b2d9e1b1ba38b102c7453bb3c8"


### PR DESCRIPTION
## What

Reference implementation of the template's landing page migrated to Experience Orchestration. Not for merge — this branch is the ground-truth example that customers and demos compare against.

Produced by the `contentful-exo-upgrade-code-rewrite` skill in [exo-upgrade-agent PR #82](https://github.com/contentful/exo-upgrade-agent/pull/82).

Ref: [ATL-541](https://contentful.atlassian.net/browse/ATL-541)

## Result

The landing page (`/`) renders end-to-end through the ExO SDK. Preview draft, published delivery, and the original app produce visually identical output.

## What changed

Additive, refactor `/` in place (no parallel route):

- `src/lib/exo/` — adapter layer (4 components + 1 template + shared utils)
- `src/pages/preview.page.tsx` — draft renderer for the editor iframe
- `src/pages/index.page.tsx` — swap the GraphQL fetch for the ExO fetch → resolve → render path
- `config/headers.js`, `next.config.js`, `src/pages/_app.page.tsx`, `src/components/templates/layout/layout.tsx` — SDK + iframe-guard wiring

`src/components/` is untouched apart from a one-line `layout.tsx` tweak so `/preview` gets the same chrome as `/`.

## Test environment

- Space: `gjo0kztdxocu`
- Environment: `ahmed-test-07-24`
- Contentful (staging): [open the space](https://app.flinkly.com/spaces/gjo0kztdxocu/environments/ahmed-test-07-24/home)
- Published Experience: `e1d023c591388c6a` — [open in editor](https://app.flinkly.com/spaces/gjo0kztdxocu/environments/ahmed-test-07-24/experiences/e1d023c591388c6a)
- Delivery host: `api.flinkly.com`



<img width="2596" height="4758" alt="screencapture-app-flinkly-spaces-gjo0kztdxocu-environments-ahmed-test-07-24-experiences-0b8172c75cdf5a71-2026-08-04-23_46_54" src="https://github.com/user-attachments/assets/7c080452-648e-439f-ae08-b4b484f55068" />


[ATL-541]: https://contentful.atlassian.net/browse/ATL-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ